### PR TITLE
support dark mode

### DIFF
--- a/markdown_live_preview/client/site.scss
+++ b/markdown_live_preview/client/site.scss
@@ -13,6 +13,17 @@ body {
   padding: 1em;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --focus-colour: #83782e;
+  }
+
+  body {
+    color: #c9d1d9;
+    background-color: #0d1117;
+  }
+}
+
 main {
   border: thin solid var(--border-colour);
   border-radius: 0.3em;


### PR DESCRIPTION
Fixes #80
github-markdown-css now switches between dark and light theme based on system colorscheme preference.

This PR adds support for dark mode. I don't really like hardcoding the color values other than (--focus-color). The alternative is to add "markdown-body" to <body> and fix any issues after. It's not necessary to be 100% consistent, so I've not done so. Let me know if you want this implemented that way.